### PR TITLE
Fix apk command

### DIFF
--- a/0.12.6/Dockerfile
+++ b/0.12.6/Dockerfile
@@ -2,7 +2,7 @@ FROM hashicorp/terraform:0.12.6
 
 ENV TFNOTIFY_VERSION=0.3.1
 
-RUN    apk add --update --no-cache --virtual .build-deps curl \
+RUN    apk add --update --no-cache --virtual .build-deps --upgrade curl \
     && curl -sL https://github.com/mercari/tfnotify/releases/download/v${TFNOTIFY_VERSION}/tfnotify_v${TFNOTIFY_VERSION}_linux_amd64.tar.gz -o /tmp/tfnotify.tar.gz \
     && tar zxvf /tmp/tfnotify.tar.gz -C /tmp \
     && cp /tmp/tfnotify_v${TFNOTIFY_VERSION}_linux_amd64/tfnotify /usr/local/bin/tfnotify \


### PR DESCRIPTION
To avoid encountering following command in 0.12.6:

```
Error relocating /usr/bin/curl: curl_multi_poll: symbol not found
```